### PR TITLE
Updated functions that accept a filter to accept None

### DIFF
--- a/drmaa2/drmaa2_object.py
+++ b/drmaa2/drmaa2_object.py
@@ -260,6 +260,12 @@ class Drmaa2Object(object):
         return ctypes_list
 
     @classmethod
+    def to_ctypes_string_list_or_none(cls, py_list):
+        if py_list is None:
+            return None
+        return self.to_ctypes_string_list(py_list)
+
+    @classmethod
     def get_implementation_specific_keys(cls):
         return cls.implementation_specific_keys
 

--- a/drmaa2/job_session.py
+++ b/drmaa2/job_session.py
@@ -497,7 +497,11 @@ class JobSession(Drmaa2Object):
         job_info = filter
         if type(filter) == PY_DICT_TYPE:
             job_info = JobInfo(filter)
-        ctypes_filter = job_info._struct
+
+        ctypes_filter = None
+        if job_info is not None:
+            ctypes_filter = job_info._struct
+
         ctypes_job_list = drmaa2_lib.drmaa2_jsession_get_jobs(self._struct, ctypes_filter)
         if not ctypes_job_list:
             self.exception_mapper.check_last_error_code()

--- a/drmaa2/monitoring_session.py
+++ b/drmaa2/monitoring_session.py
@@ -129,7 +129,7 @@ class MonitoringSession(Drmaa2Object):
         """
         self.logger.debug('Requesting list of machines using filter: {}'.format(filter))
         drmaa2_lib = self.get_drmaa2_library()
-        ctypes_filter = self.to_ctypes_string_list(filter)
+        ctypes_filter = self.to_ctypes_string_list_or_none(filter)
         ctypes_machine_info_list = drmaa2_lib.drmaa2_msession_get_all_machines(self._struct, ctypes_filter)
         if not ctypes_machine_info_list:
             self.exception_mapper.check_last_error_code()
@@ -156,7 +156,7 @@ class MonitoringSession(Drmaa2Object):
         """
         self.logger.debug('Requesting list of queues using filter: {}'.format(filter))
         drmaa2_lib = self.get_drmaa2_library()
-        ctypes_filter = self.to_ctypes_string_list(filter)
+        ctypes_filter = self.to_ctypes_string_list_or_none(filter)
         ctypes_queue_info_list = drmaa2_lib.drmaa2_msession_get_all_queues(self._struct, ctypes_filter)
         if not ctypes_queue_info_list:
             self.exception_mapper.check_last_error_code()
@@ -187,7 +187,11 @@ class MonitoringSession(Drmaa2Object):
         reservation_info = filter
         if type(filter) == PY_DICT_TYPE:
             reservation_info = ReservationInfo(filter)
-        ctypes_filter = reservation_info._struct
+
+        ctypes_filter = None
+        if reservation_info is not None:
+            ctypes_filter = reservation_info._struct
+
         ctypes_reservation_list = drmaa2_lib.drmaa2_msession_get_all_reservations(self._struct, ctypes_filter)
         if not ctypes_reservation_list:
             self.exception_mapper.check_last_error_code()
@@ -215,7 +219,11 @@ class MonitoringSession(Drmaa2Object):
         job_info = filter
         if type(filter) == PY_DICT_TYPE:
             job_info = JobInfo(filter)
-        ctypes_filter = job_info._struct
+
+        ctypes_filter = None
+        if job_info is not None:
+            ctypes_filter = job_info._struct
+
         ctypes_job_list = drmaa2_lib.drmaa2_msession_get_all_jobs(self._struct, ctypes_filter)
         if not ctypes_job_list:
             self.exception_mapper.check_last_error_code()

--- a/drmaa2/reservation.py
+++ b/drmaa2/reservation.py
@@ -122,10 +122,11 @@ class Reservation(Drmaa2Object):
     def to_py_reservation_list(cls, ctypes_list):
         py_reservation_list = list()
         if ctypes_list:
-            count = cls.drmaa2_lib.drmaa2_list_size(ctypes_list)
+            drmaa2_lib = cls.get_drmaa2_library()
+            count = drmaa2_lib.drmaa2_list_size(ctypes_list)
             cls.logger.debug('Converting ctypes reservation list of size {}'.format(count))
             for i in range(count):
-                void_ptr = cls.drmaa2_lib.drmaa2_list_get(ctypes_list, i)
+                void_ptr = drmaa2_lib.drmaa2_list_get(ctypes_list, i)
                 if void_ptr:
                     r = cast(void_ptr, POINTER(drmaa2_r))
                     r = Reservation(r)


### PR DESCRIPTION
In the DRMAA2 C API functions that accept a filter can be passed NULL to request everything be returned. The current Python implementation does not allow this however.

Updated:

- `JobSession.get_jobs`
- `MonitoringSession.get_all_machines`
- `MonitoringSession.get_all_queues`
- `MonitoringSession.get_all_reservations`
 
to accept None to mirror the use of NULL. Also fixed a bug in `Reservation.to_py_reservation_list` referencing a non-existent attribute of the class.